### PR TITLE
Define href for attachments

### DIFF
--- a/src/blots/AttachmentBlot/index.js
+++ b/src/blots/AttachmentBlot/index.js
@@ -6,6 +6,7 @@ let BlockEmbed = Quill.import("blots/block/embed");
 class AttachmentBlot extends BlockEmbed {
   static create(value) {
     let id;
+    let href;
 
     const arr = `${value}`.split(Constants.ID_SPLIT_FLAG);
     if (arr.length > 1) {


### PR DESCRIPTION
This PR fixes the issue in #44 by by defining `href` which has been missing.