### PR TITLE
Issue when user tries to upload a different file extension than the ones allowed in image or video upload, spinner shows and no error message is shown to user #52

### DIFF
--- a/src/handlers/ImageHandler/index.js
+++ b/src/handlers/ImageHandler/index.js
@@ -14,7 +14,7 @@ class ImageHandler extends BaseHandler {
   }
 
   fileChanged() {
-    const file = this.loadFile(this);
+    const file = this.fileHolder.files[0];
     const extension = file.name.split(".").pop();
 
     if (!this.isImage(extension)) {
@@ -23,7 +23,8 @@ class ImageHandler extends BaseHandler {
       );
       return;
     }
-
+  
+    this.loadFile(this);
     this.embedFile(file);
   }
 }


### PR DESCRIPTION
When the user tries to upload a different file extension than the ones allowed in image or video upload, spinner is shown and there is an error on console: "[Wrong Format] Format was wrong, please try with image format correctly!!"

Steps for Reproduction
Access the quill js editor.
Click on image upload, the file modal opens.
Click on All files for the extension and add pdf, excel or any other extension the image upload is not allowed
Spinner is shown in quill editor and there is a console warning: "[Wrong Format] Format was wrong, please try with image format correctly!!"

Expected behavior:
The user should not be able to add any other file than the allowed extensions and also alert error message should be shown to user for an invalid format

Actual behavior:
Spinner is shown in quill editor and there is a console warning: "[Wrong Format] Format was wrong, please try with image format correctly!!".

The same happens with video upload.